### PR TITLE
Fix priest Mental Agility talent rank values

### DIFF
--- a/assets/talents/priest.json
+++ b/assets/talents/priest.json
@@ -4,7 +4,7 @@
 		{
 			"name":"mental_agility",
 			"maxRank":5,
-			"rankIncrement":1,
+			"rankIncrement":2,
 			"description":"Reduces the mana cost of your instant cast spells by ${rankIncrement}%.",
 			"image":"mental_agility.jpg",
 			"affectedSpells": [


### PR DESCRIPTION
Hello,

Mental Agility is supposed to rank up to 10% on 2% increments, see max rank : https://classic.wowhead.com/spell=14783/mental-agility
This PR fixes the rankIncrement field of this talent to match ingame values.

Very nice work by the way, thanks !